### PR TITLE
Fixed default close and missing icons

### DIFF
--- a/Innovator/Client/scripts/innovator.aspx
+++ b/Innovator/Client/scripts/innovator.aspx
@@ -28,6 +28,8 @@
 			#banner{
 				height: <%=ICC.BannerHeight.ToString()%>px;
 			}
+			
+			/* Start Filter TOC Modifications */
 			.filterContainer {
 				margin: 0 2px 5px 15px;
 				position: relative;
@@ -50,6 +52,8 @@
 				top: 0px;
 				border: none;
 			}
+			/* End Filter TOC Modifications */
+
 		</style>
 		<!-- #INCLUDE FILE="include/InitialSetupHeader.aspx" -->
 		<script src="./external/jquery-3.2.1.min.js"></script>
@@ -76,6 +80,7 @@
 			}
 
 			stopTimeBannersUpdate();
+			
 			//Onunload handler does not start in Chrome when the opener are closed.
 			//As a result, save preference and logout not called.
 			if (aras.Browser.isCh() && !window.opener) {
@@ -83,6 +88,8 @@
 				aras.logout();
 			}
 		};
+		
+		// Start Filter TOC Modifications
 		
 		// override the jquery 'contains' filter to be case insensitive
 		jQuery.expr[':'].contains = function(a, i, m) {
@@ -92,9 +99,13 @@
 		function showAllTOCNodes() {
 			$('.aras-nav').each(function() {
 				$(this).find('*').show();
-				$(this).find('.aras-nav-parent_expanded').removeClass('aras-nav-parent_expanded');
+				
+				var item = document.item;
+				var thisItem = document.thisItem;
 			})
 			
+			var elements = $('.aras-nav-toc').find("span").parents('.aras-nav-parent_expanded').not('.hadbefore_aras-nav-parent_expanded');
+			elements.removeClass('aras-nav-parent_expanded');
 		}
 		
 		function hideAllTOCNodes() {
@@ -105,18 +116,42 @@
 		
 		function showParentsUntilRootTOC(val) {
 			$('.aras-nav-toc').find("span:contains('" + val + "')").show();
+			$('.aras-nav-toc').find("span:contains('" + val + "')").parent().find("img").show();
 			$('.aras-nav-toc').find("span:contains('" + val + "')").parentsUntil(".aras-nav").show();
 			$('.aras-nav-toc').find("span:contains('" + val + "')").parentsUntil(".aras-nav").children('div,svg').show();
 			$('.aras-nav-toc').find("span:contains('" + val + "')").parentsUntil(".aras-nav").children('div,svg').find('*').show();
-			$('.aras-nav-toc').find("span:contains('" + val + "')").parents('.aras-nav-parent').addClass('aras-nav-parent_expanded')
+			$('.aras-nav-toc').find("span:contains('" + val + "')").parents('.aras-nav-parent').addClass('aras-nav-parent_expanded');
 		}
 		
 		function clearFilter() {
-			$('#filterTOC').val('');
-			showAllTOCNodes();
+			var tValue = $('#filterTOC').val();
+			
+			if (tValue != null && tValue != '')
+			{
+				$('#filterTOC').val('');
+				showAllTOCNodes();
+			}	
+			
+			//filter is already cleared -> mark expanded TOC nodes
+			if (tValue.length == 0)
+			{	
+				var alreadyThereElements = $('.aras-nav-toc').find('span').parents('.aras-nav-parent_expanded');
+				alreadyThereElements.addClass('hadbefore_aras-nav-parent_expanded');
+			}
 		}
 		
-		onkeyupfilter = function() {
+		function onFilterFocus() {
+		    //onkeyup sometimes gets triggered too late -> so mark expanded TOC nodes on focus
+			var filter = document.getElementById("filterTOC");
+			var val = filter.value;
+			if (val.length == 0)
+			{
+				var alreadyThereElements = $('.aras-nav-toc').find('span').parents('.aras-nav-parent_expanded');
+				alreadyThereElements.addClass('hadbefore_aras-nav-parent_expanded');
+			}
+		}
+		
+		function onkeyupfilter(event) {
 			// Get the value to filter by
 			var filter = document.getElementById("filterTOC");
 			var val = filter.value;
@@ -125,6 +160,14 @@
 			{
 				showAllTOCNodes();
 				return;
+			}
+			
+			//first character typed so list is not filtered yet -> mark expanded TOC nodes
+			var key = event.keyCode;
+			if ((val.length == 1 && key != 8))
+			{	
+				var alreadyThereElements = $('.aras-nav-toc').find('span').parents('.aras-nav-parent_expanded');
+				alreadyThereElements.addClass('hadbefore_aras-nav-parent_expanded');
 			}
 			
 			// Get the TOC container
@@ -139,11 +182,10 @@
 			var elemsToShow = [];
 			
 			hideAllTOCNodes();
-			
 			showParentsUntilRootTOC(val);
 		}
 		
-
+		// End Filter TOC Modifications
 		</script>
 	</head>
 	<body class="claro">
@@ -214,10 +256,12 @@
 						<span class="aras-icon-arrow aras-icon-arrow_left"></span>
 					</div>
 				</div>
+				<!-- Start Filter TOC Modifications -->
 				<div class="filterContainer">
-					<input type="text" id="filterTOC" onkeyup="onkeyupfilter()" placeholder="Filter..." />
+					<input type="text" id="filterTOC" onkeyup="onkeyupfilter(event)" onfocus="onFilterFocus()" placeholder="Filter..." />
 					<input type="image" src="..\images\Delete.svg" id="clearFilterButton" onclick="clearFilter()" />
 				</div>
+				<!-- End Filter TOC Modifications -->
 				<div class="aras-nav-toc"></div>
 			</div>
 			<div class="aras-splitter" id="main-container-splitter"></div>

--- a/Innovator/Client/scripts/innovator.aspx
+++ b/Innovator/Client/scripts/innovator.aspx
@@ -162,14 +162,6 @@
 				return;
 			}
 			
-			//first character typed so list is not filtered yet -> mark expanded TOC nodes
-			var key = event.keyCode;
-			if ((val.length == 1 && key != 8))
-			{	
-				var alreadyThereElements = $('.aras-nav-toc').find('span').parents('.aras-nav-parent_expanded');
-				alreadyThereElements.addClass('hadbefore_aras-nav-parent_expanded');
-			}
-			
 			// Get the TOC container
 			var toc = document.getElementsByClassName("aras-nav-toc");
 			if (!toc || toc.length < 1)


### PR DESCRIPTION
I fixed the bug that default closed all folders after clearing a search. To accomplish this all opened folders are marked with a special CSS class before the search starts. After clearing a search all folders excepted the ones which were open before are closed. 

In addition to that I fixed the bug that images of another format than SVG not show in a search.